### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Attach the colorListener
         });
 ```
 
-###Tweaking
+### Tweaking
 =======================
 If you change the wheel color drawable, then you'll probably want to change the radius offset.
 To get a better view, enable the debug drawing as followed.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
